### PR TITLE
refactor: enable context isolation with preload

### DIFF
--- a/src/components/app/CheatingDaddyApp.js
+++ b/src/components/app/CheatingDaddyApp.js
@@ -156,9 +156,9 @@ export class CheatingDaddyApp extends LitElement {
     connectedCallback() {
         super.connectedCallback();
 
-        // Set up IPC listeners if needed
-        if (window.require) {
-            const { ipcRenderer } = window.require('electron');
+        // Set up IPC listeners if available
+        if (window.ipcRenderer) {
+            const ipcRenderer = window.ipcRenderer;
             ipcRenderer.on('update-response', (_, response) => {
                 this.setResponse(response);
             });
@@ -224,8 +224,8 @@ export class CheatingDaddyApp extends LitElement {
         }
 
         super.disconnectedCallback();
-        if (window.require) {
-            const { ipcRenderer } = window.require('electron');
+        if (window.ipcRenderer) {
+            const ipcRenderer = window.ipcRenderer;
             ipcRenderer.removeAllListeners('update-response');
             ipcRenderer.removeAllListeners('update-status');
             ipcRenderer.removeAllListeners('click-through-toggled');
@@ -303,8 +303,8 @@ export class CheatingDaddyApp extends LitElement {
             cheddar.stopCapture();
 
             // Close the session
-            if (window.require) {
-                const { ipcRenderer } = window.require('electron');
+            if (window.ipcRenderer) {
+                const ipcRenderer = window.ipcRenderer;
                 await ipcRenderer.invoke('close-session');
             }
             this.sessionActive = false;
@@ -312,16 +312,16 @@ export class CheatingDaddyApp extends LitElement {
             console.log('Session closed');
         } else {
             // Quit the entire application
-            if (window.require) {
-                const { ipcRenderer } = window.require('electron');
+            if (window.ipcRenderer) {
+                const ipcRenderer = window.ipcRenderer;
                 await ipcRenderer.invoke('quit-application');
             }
         }
     }
 
     async handleHideToggle() {
-        if (window.require) {
-            const { ipcRenderer } = window.require('electron');
+        if (window.ipcRenderer) {
+            const ipcRenderer = window.ipcRenderer;
             await ipcRenderer.invoke('toggle-window-visibility');
         }
     }
@@ -349,8 +349,8 @@ export class CheatingDaddyApp extends LitElement {
     }
 
     async handleAPIKeyHelp() {
-        if (window.require) {
-            const { ipcRenderer } = window.require('electron');
+        if (window.ipcRenderer) {
+            const ipcRenderer = window.ipcRenderer;
             await ipcRenderer.invoke('open-external', 'https://cheatingdaddy.com/help/api-key');
         }
     }
@@ -385,8 +385,8 @@ export class CheatingDaddyApp extends LitElement {
 
     // Help view event handlers
     async handleExternalLinkClick(url) {
-        if (window.require) {
-            const { ipcRenderer } = window.require('electron');
+        if (window.ipcRenderer) {
+            const ipcRenderer = window.ipcRenderer;
             await ipcRenderer.invoke('open-external', url);
         }
     }
@@ -419,8 +419,8 @@ export class CheatingDaddyApp extends LitElement {
         super.updated(changedProperties);
 
         // Only notify main process of view change if the view actually changed
-        if (changedProperties.has('currentView') && window.require) {
-            const { ipcRenderer } = window.require('electron');
+        if (changedProperties.has('currentView') && window.ipcRenderer) {
+            const ipcRenderer = window.ipcRenderer;
             ipcRenderer.send('view-changed', this.currentView);
 
             // Add a small delay to smooth out the transition
@@ -568,9 +568,9 @@ export class CheatingDaddyApp extends LitElement {
         this.updateLayoutMode();
 
         // Notify main process about layout change for window resizing
-        if (window.require) {
+        if (window.ipcRenderer) {
             try {
-                const { ipcRenderer } = window.require('electron');
+                const ipcRenderer = window.ipcRenderer;
                 await ipcRenderer.invoke('update-sizes');
             } catch (error) {
                 console.error('Failed to update sizes in main process:', error);

--- a/src/components/views/AdvancedView.js
+++ b/src/components/views/AdvancedView.js
@@ -399,8 +399,8 @@ export class AdvancedView extends LitElement {
                 this.requestUpdate();
                 setTimeout(async () => {
                     // Close the entire application
-                    if (window.require) {
-                        const { ipcRenderer } = window.require('electron');
+                    if (window.ipcRenderer) {
+                        const ipcRenderer = window.ipcRenderer;
                         await ipcRenderer.invoke('quit-application');
                     }
                 }, 1000);
@@ -477,8 +477,8 @@ export class AdvancedView extends LitElement {
         localStorage.setItem('contentProtection', this.contentProtection.toString());
         
         // Update the window's content protection in real-time
-        if (window.require) {
-            const { ipcRenderer } = window.require('electron');
+        if (window.ipcRenderer) {
+            const ipcRenderer = window.ipcRenderer;
             try {
                 await ipcRenderer.invoke('update-content-protection', this.contentProtection);
             } catch (error) {

--- a/src/components/views/AssistantView.js
+++ b/src/components/views/AssistantView.js
@@ -443,8 +443,8 @@ export class AssistantView extends LitElement {
         this.loadFontSize();
 
         // Set up IPC listeners for keyboard shortcuts
-        if (window.require) {
-            const { ipcRenderer } = window.require('electron');
+        if (window.ipcRenderer) {
+            const ipcRenderer = window.ipcRenderer;
 
             this.handlePreviousResponse = () => {
                 console.log('Received navigate-previous-response message');
@@ -477,8 +477,8 @@ export class AssistantView extends LitElement {
         super.disconnectedCallback();
 
         // Clean up IPC listeners
-        if (window.require) {
-            const { ipcRenderer } = window.require('electron');
+        if (window.ipcRenderer) {
+            const ipcRenderer = window.ipcRenderer;
             if (this.handlePreviousResponse) {
                 ipcRenderer.removeListener('navigate-previous-response', this.handlePreviousResponse);
             }

--- a/src/components/views/CustomizeView.js
+++ b/src/components/views/CustomizeView.js
@@ -605,8 +605,8 @@ export class CustomizeView extends LitElement {
     saveKeybinds() {
         localStorage.setItem('customKeybinds', JSON.stringify(this.keybinds));
         // Send to main process to update global shortcuts
-        if (window.require) {
-            const { ipcRenderer } = window.require('electron');
+        if (window.ipcRenderer) {
+            const ipcRenderer = window.ipcRenderer;
             ipcRenderer.send('update-keybinds', this.keybinds);
         }
     }
@@ -621,8 +621,8 @@ export class CustomizeView extends LitElement {
         this.keybinds = this.getDefaultKeybinds();
         localStorage.removeItem('customKeybinds');
         this.requestUpdate();
-        if (window.require) {
-            const { ipcRenderer } = window.require('electron');
+        if (window.ipcRenderer) {
+            const ipcRenderer = window.ipcRenderer;
             ipcRenderer.send('update-keybinds', this.keybinds);
         }
     }
@@ -774,9 +774,9 @@ export class CustomizeView extends LitElement {
         localStorage.setItem('googleSearchEnabled', this.googleSearchEnabled.toString());
 
         // Notify main process if available
-        if (window.require) {
+        if (window.ipcRenderer) {
             try {
-                const { ipcRenderer } = window.require('electron');
+                const ipcRenderer = window.ipcRenderer;
                 await ipcRenderer.invoke('update-google-search-setting', this.googleSearchEnabled);
             } catch (error) {
                 console.error('Failed to notify main process:', error);

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,2 +1,10 @@
-// See the Electron documentation for details on how to use preload scripts:
-// https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('ipcRenderer', {
+  send: (channel, ...args) => ipcRenderer.send(channel, ...args),
+  invoke: (channel, ...args) => ipcRenderer.invoke(channel, ...args),
+  on: (channel, listener) => ipcRenderer.on(channel, listener),
+  once: (channel, listener) => ipcRenderer.once(channel, listener),
+  removeListener: (channel, listener) => ipcRenderer.removeListener(channel, listener),
+  removeAllListeners: channel => ipcRenderer.removeAllListeners(channel),
+});

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -40,8 +40,9 @@ function createWindow(sendToRenderer, geminiSessionRef, randomNames = null) {
         skipTaskbar: true,
         hiddenInMissionControl: true,
         webPreferences: {
-            nodeIntegration: true,
-            contextIsolation: false, // TODO: change to true
+            nodeIntegration: false,
+            contextIsolation: true,
+            preload: path.join(__dirname, '../preload.js'),
             backgroundThrottling: false,
             enableBlinkFeatures: 'GetDisplayMedia',
             webSecurity: true,

--- a/src/utils/windowResize.js
+++ b/src/utils/windowResize.js
@@ -1,7 +1,7 @@
 export async function resizeLayout() {
     try {
-        if (window.require) {
-            const { ipcRenderer } = window.require('electron');
+        if (window.ipcRenderer) {
+            const ipcRenderer = window.ipcRenderer;
             const result = await ipcRenderer.invoke('update-sizes');
             if (result.success) {
                 console.log('Window resized for current view');


### PR DESCRIPTION
## Summary
- enforce secure renderer configuration with context isolation and no node integration
- expose ipcRenderer via preload bridge
- update renderer modules to use window.ipcRenderer instead of window.require

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a47d81bdd88331a1d8416733c59c84