### PR TITLE
Handle media permission errors with callbacks and cleanup

### DIFF
--- a/apps/desktop/src/ui/App.tsx
+++ b/apps/desktop/src/ui/App.tsx
@@ -49,24 +49,22 @@ export function App() {
   }
 
   async function startMic() {
-    try {
-      if (!audioRef.current) audioRef.current = new AudioCapture({
-        onPcm16Base64: (b64) => client.sendPcm16Base64(b64),
-        onLocalPCM16: async (pcm16) => {
-          if (!s.localAsr) return;
-          try {
-            const text = await transcribePCM16(pcm16);
-            if (text) s.addLog({ kind: 'status', text: `[local ASR] ${text}` });
-          } catch (e:any) {
-            s.addLog({ kind: 'error', text: `local ASR error: ${String(e)}` });
-          }
+    if (!audioRef.current) audioRef.current = new AudioCapture({
+      onPcm16Base64: (b64) => client.sendPcm16Base64(b64),
+      onLocalPCM16: async (pcm16) => {
+        if (!s.localAsr) return;
+        try {
+          const text = await transcribePCM16(pcm16);
+          if (text) s.addLog({ kind: 'status', text: `[local ASR] ${text}` });
+        } catch (e:any) {
+          s.addLog({ kind: 'error', text: `local ASR error: ${String(e)}` });
         }
-      });
-      await audioRef.current.start();
+      },
+      onError: (e) => s.addLog({ kind: 'error', text: `Mic error: ${String(e)}` }),
+    });
+    await audioRef.current.start().then(() => {
       s.addLog({ kind: 'status', text: 'Mic started' });
-    } catch (err: any) {
-      s.addLog({ kind: 'error', text: `Mic error: ${String(err)}` });
-    }
+    }).catch(() => {});
   }
 
   async function stopMic() {
@@ -76,25 +74,23 @@ export function App() {
   }
 
   async function shareScreen() {
-    try {
-      if (!screenRef.current) screenRef.current = new ScreenCapture({
-        fps: s.screenFrameFps,
-        onJpegBase64: (b64) => client.sendJpegBase64(b64),
-        onLocalJpegBytes: async (bytes) => {
-          if (!s.localOcr) return;
-          try {
-            const text = await ocrBytes(bytes);
-            if (text) s.addLog({ kind: 'status', text: `[local OCR] ${text.slice(0,200)}${text.length>200?'…':''}` });
-          } catch (e:any) {
-            s.addLog({ kind: 'error', text: `local OCR error: ${String(e)}` });
-          }
+    if (!screenRef.current) screenRef.current = new ScreenCapture({
+      fps: s.screenFrameFps,
+      onJpegBase64: (b64) => client.sendJpegBase64(b64),
+      onLocalJpegBytes: async (bytes) => {
+        if (!s.localOcr) return;
+        try {
+          const text = await ocrBytes(bytes);
+          if (text) s.addLog({ kind: 'status', text: `[local OCR] ${text.slice(0,200)}${text.length>200?'…':''}` });
+        } catch (e:any) {
+          s.addLog({ kind: 'error', text: `local OCR error: ${String(e)}` });
         }
-      });
-      await screenRef.current.start();
+      },
+      onError: (e) => s.addLog({ kind: 'error', text: `Screen error: ${String(e)}` }),
+    });
+    await screenRef.current.start().then(() => {
       s.addLog({ kind: 'status', text: 'Screen sharing started' });
-    } catch (err: any) {
-      s.addLog({ kind: 'error', text: `Screen error: ${String(err)}` });
-    }
+    }).catch(() => {});
   }
 
   async function stopScreen() {

--- a/apps/desktop/src/utils/AudioCapture.ts
+++ b/apps/desktop/src/utils/AudioCapture.ts
@@ -2,6 +2,7 @@
 type Opts = {
   onPcm16Base64?: (b64: string) => void; // streamed to WS
   onLocalPCM16?: (pcm: Int16Array) => void; // for local ASR
+  onError?: (err: unknown) => void;
 };
 
 export class AudioCapture {
@@ -14,27 +15,33 @@ export class AudioCapture {
 
   async start() {
     if (this.ctx) return;
-    this.ctx = new AudioContext({ sampleRate: 48000 });
-    await this.ctx.audioWorklet.addModule(new URL('./pcm16-worklet.js', import.meta.url).toString());
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true } });
-    this.mediaStream = stream;
-    const src = this.ctx.createMediaStreamSource(stream);
-    this.workletNode = new AudioWorkletNode(this.ctx, 'pcm16-worklet', { processorOptions: { targetSampleRate: 16000 } });
-    this.workletNode.port.onmessage = (e) => {
-      const bytes = e.data as Uint8Array;
-      // WS streaming
-      if (this.opts.onPcm16Base64) {
-        const b64 = btoa(String.fromCharCode(...bytes));
-        this.opts.onPcm16Base64(b64);
-      }
-      // Local ASR
-      if (this.opts.onLocalPCM16) {
-        const i16 = new Int16Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
-        this.opts.onLocalPCM16(i16);
-      }
-    };
-    src.connect(this.workletNode);
-    this.workletNode.connect(this.ctx.destination); // keep graph alive
+    try {
+      this.ctx = new AudioContext({ sampleRate: 48000 });
+      await this.ctx.audioWorklet.addModule(new URL('./pcm16-worklet.js', import.meta.url).toString());
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true } });
+      this.mediaStream = stream;
+      const src = this.ctx.createMediaStreamSource(stream);
+      this.workletNode = new AudioWorkletNode(this.ctx, 'pcm16-worklet', { processorOptions: { targetSampleRate: 16000 } });
+      this.workletNode.port.onmessage = (e) => {
+        const bytes = e.data as Uint8Array;
+        // WS streaming
+        if (this.opts.onPcm16Base64) {
+          const b64 = btoa(String.fromCharCode(...bytes));
+          this.opts.onPcm16Base64(b64);
+        }
+        // Local ASR
+        if (this.opts.onLocalPCM16) {
+          const i16 = new Int16Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+          this.opts.onLocalPCM16(i16);
+        }
+      };
+      src.connect(this.workletNode);
+      this.workletNode.connect(this.ctx.destination); // keep graph alive
+    } catch (err) {
+      await this.stop();
+      if (this.opts.onError) this.opts.onError(err);
+      throw err;
+    }
   }
 
   async stop() {
@@ -44,5 +51,9 @@ export class AudioCapture {
     this.mediaStream = null;
     await this.ctx?.close();
     this.ctx = null;
+  }
+
+  async dispose() {
+    await this.stop();
   }
 }

--- a/apps/desktop/src/utils/ScreenCapture.ts
+++ b/apps/desktop/src/utils/ScreenCapture.ts
@@ -3,6 +3,7 @@ type Opts = {
   fps: number;
   onJpegBase64?: (b64: string) => void;
   onLocalJpegBytes?: (bytes: Uint8Array) => void; // for OCR
+  onError?: (err: unknown) => void;
 };
 
 export class ScreenCapture {
@@ -21,40 +22,50 @@ export class ScreenCapture {
   }
 
   async start() {
-    this.stream = await (navigator.mediaDevices as any).getDisplayMedia({ video: { frameRate: 15 }, audio: false });
-    const track = this.stream.getVideoTracks()[0];
-    const settings = track.getSettings();
-    const width = Math.min(1280, (settings.width as number) || 1280);
-    const height = Math.min(800, (settings.height as number) || 800);
-    this.canvas.width = width;
-    this.canvas.height = height;
+    try {
+      this.stream = await (navigator.mediaDevices as any).getDisplayMedia({ video: { frameRate: 15 }, audio: false });
+      const track = this.stream.getVideoTracks()[0];
+      const settings = track.getSettings();
+      const width = Math.min(1280, (settings.width as number) || 1280);
+      const height = Math.min(800, (settings.height as number) || 800);
+      this.canvas.width = width;
+      this.canvas.height = height;
 
-    const video = document.createElement('video');
-    video.srcObject = this.stream;
-    await video.play();
+      const video = document.createElement('video');
+      video.srcObject = this.stream;
+      await video.play();
 
-    const interval = Math.max(200, 1000 / (this.opts.fps || 1));
-    const loop = async () => {
-      this.ctx.drawImage(video, 0, 0, this.canvas.width, this.canvas.height);
-      const blob = await new Promise<Blob | null>((resolve) => this.canvas.toBlob(b => resolve(b), 'image/jpeg', 0.6));
-      if (blob) {
-        const bytes = new Uint8Array(await blob.arrayBuffer());
-        if (this.opts.onJpegBase64) {
-          const b64 = btoa(String.fromCharCode(...bytes));
-          this.opts.onJpegBase64(b64);
+      const interval = Math.max(200, 1000 / (this.opts.fps || 1));
+      const loop = async () => {
+        this.ctx.drawImage(video, 0, 0, this.canvas.width, this.canvas.height);
+        const blob = await new Promise<Blob | null>((resolve) => this.canvas.toBlob(b => resolve(b), 'image/jpeg', 0.6));
+        if (blob) {
+          const bytes = new Uint8Array(await blob.arrayBuffer());
+          if (this.opts.onJpegBase64) {
+            const b64 = btoa(String.fromCharCode(...bytes));
+            this.opts.onJpegBase64(b64);
+          }
+          if (this.opts.onLocalJpegBytes) {
+            this.opts.onLocalJpegBytes(bytes);
+          }
         }
-        if (this.opts.onLocalJpegBytes) {
-          this.opts.onLocalJpegBytes(bytes);
-        }
-      }
-      this.handle = self.setTimeout(loop, interval) as any;
-    };
-    loop();
+        this.handle = self.setTimeout(loop, interval) as any;
+      };
+      loop();
+    } catch (err) {
+      await this.stop();
+      if (this.opts.onError) this.opts.onError(err);
+      throw err;
+    }
   }
 
   async stop() {
     if (this.handle) { clearTimeout(this.handle); this.handle = null; }
     this.stream?.getTracks().forEach(t => t.stop());
     this.stream = null;
+  }
+
+  async dispose() {
+    await this.stop();
   }
 }

--- a/apps/desktop/test/capture-permissions.test.ts
+++ b/apps/desktop/test/capture-permissions.test.ts
@@ -1,0 +1,45 @@
+// apps/desktop/test/capture-permissions.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { AudioCapture } from '../src/utils/AudioCapture';
+import { ScreenCapture } from '../src/utils/ScreenCapture';
+
+// Helpers to restore globals after tests
+function restore() {
+  vi.unstubAllGlobals();
+}
+
+describe('AudioCapture permission denials', () => {
+  it('calls onError and cleans up when getUserMedia is denied', async () => {
+    const err = new Error('denied');
+    const onError = vi.fn();
+    const closeFn = vi.fn().mockResolvedValue(undefined);
+    class MockAudioContext {
+      audioWorklet = { addModule: vi.fn().mockResolvedValue(undefined) };
+      close = closeFn;
+    }
+    vi.stubGlobal('AudioContext', MockAudioContext as any);
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia: vi.fn().mockRejectedValue(err) } });
+
+    const ac = new AudioCapture({ onError });
+    await expect(ac.start()).rejects.toThrow('denied');
+    expect(onError).toHaveBeenCalledWith(err);
+    expect(closeFn).toHaveBeenCalled();
+    // @ts-ignore accessing private for test
+    expect(ac['ctx']).toBeNull();
+    restore();
+  });
+});
+
+describe('ScreenCapture permission denials', () => {
+  it('calls onError when getDisplayMedia is denied', async () => {
+    const err = new Error('denied');
+    const onError = vi.fn();
+    vi.stubGlobal('navigator', { mediaDevices: { getDisplayMedia: vi.fn().mockRejectedValue(err) } });
+    vi.stubGlobal('document', { createElement: () => ({ getContext: () => ({}) }) });
+
+    const sc = new ScreenCapture({ fps: 1, onError });
+    await expect(sc.start()).rejects.toThrow('denied');
+    expect(onError).toHaveBeenCalledWith(err);
+    restore();
+  });
+});


### PR DESCRIPTION
## Summary
- wrap microphone and screen capture requests in try/catch to surface errors via optional `onError` callbacks
- clean up partial audio/screen capture setups via `stop`/`dispose`
- add unit tests for media permission denials

## Testing
- `cd apps/desktop && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1d351fbec8331b3cf525d8a4cf028