### PR TITLE
refactor: add IPC channels for settings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,19 +75,33 @@ function setupGeneralIpcHandlers() {
         }
     });
 
-    ipcMain.handle('update-content-protection', async () => {
+    ipcMain.handle('update-content-protection', async (_event, enabled) => {
         try {
             if (mainWindow) {
-                // Get content protection setting from localStorage via cheddar
-                const contentProtection = await mainWindow.webContents.executeJavaScript('cheddar.getContentProtection()');
+                const contentProtection = typeof enabled === 'boolean' ? enabled : true;
                 mainWindow.setContentProtection(contentProtection);
                 console.log('Content protection updated:', contentProtection);
+                return { success: true, value: contentProtection };
             }
-            return { success: true };
+            return { success: false, error: 'No main window' };
         } catch (error) {
             console.error('Error updating content protection:', error);
             return { success: false, error: error.message };
         }
+    });
+
+    ipcMain.handle('settings-get', async (_event, key) => {
+        try {
+            if (mainWindow) {
+                const value = await mainWindow.webContents.executeJavaScript(
+                    `localStorage.getItem(${JSON.stringify(key)})`
+                );
+                return value;
+            }
+        } catch (error) {
+            console.error('Error getting setting', key, error);
+        }
+        return null;
     });
 
     ipcMain.handle('get-random-display-name', async () => {

--- a/src/utils/__tests__/sessionManager.test.js
+++ b/src/utils/__tests__/sessionManager.test.js
@@ -7,6 +7,34 @@ test('getStoredSetting returns default without Electron', async () => {
     assert.strictEqual(value, 'default');
 });
 
+test('getStoredSetting uses IPC when available', async () => {
+    global.window = {
+        electron: {
+            ipcRenderer: {
+                invoke: async () => 'ipc-value',
+            },
+        },
+    };
+    const value = await sessionManager.getStoredSetting('key', 'fallback');
+    assert.strictEqual(value, 'ipc-value');
+    delete global.window;
+});
+
+test('getStoredSetting falls back on IPC error', async () => {
+    global.window = {
+        electron: {
+            ipcRenderer: {
+                invoke: async () => {
+                    throw new Error('fail');
+                },
+            },
+        },
+    };
+    const value = await sessionManager.getStoredSetting('key', 'fallback');
+    assert.strictEqual(value, 'fallback');
+    delete global.window;
+});
+
 test('getEnabledTools respects googleSearch setting', async () => {
     const original = sessionManager.getStoredSetting;
     sessionManager.getStoredSetting = async () => 'false';

--- a/src/utils/sessionManager.js
+++ b/src/utils/sessionManager.js
@@ -10,23 +10,14 @@ let messageBuffer = '';
 
 async function getStoredSetting(key, defaultValue) {
     try {
-        const { BrowserWindow } = require('electron');
-        const windows = BrowserWindow.getAllWindows();
-        if (windows.length > 0) {
-            await new Promise(resolve => setTimeout(resolve, 100));
-            const value = await windows[0].webContents.executeJavaScript(`
-                (function() {
-                    try {
-                        if (typeof localStorage === 'undefined') {
-                            return '${defaultValue}';
-                        }
-                        const stored = localStorage.getItem('${key}');
-                        return stored || '${defaultValue}';
-                    } catch (e) {
-                        return '${defaultValue}';
-                    }
-                })()`);
-            return value;
+        if (global.window?.electron?.ipcRenderer?.invoke) {
+            const result = await global.window.electron.ipcRenderer.invoke(
+                'settings-get',
+                key
+            );
+            if (typeof result === 'string') {
+                return result;
+            }
         }
     } catch (error) {
         console.error('Error getting stored setting for', key, ':', error.message);


### PR DESCRIPTION
## Summary
- replace executeJavaScript usage with settings-get IPC channel
- validate content protection updates passed from renderer
- test IPC setting retrieval and fallbacks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4cd0454088331935660151b946a6b