### PR TITLE
Add tests for gemini session and reconnection error flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/src/utils/__tests__/gemini.test.js
+++ b/src/utils/__tests__/gemini.test.js
@@ -1,0 +1,93 @@
+const { test, mock } = require('node:test');
+const assert = require('node:assert');
+
+// Mock Electron ipcMain
+let handlers = {};
+const ipcMain = {
+    handle(channel, fn) {
+        handlers[channel] = fn;
+    },
+};
+require.cache[require.resolve('electron')] = { exports: { ipcMain } };
+
+// Mock dependencies
+const audioHandler = {
+    stopMacOSAudioCapture: mock.fn(),
+    startMacOSAudioCapture: mock.fn(),
+};
+require.cache[require.resolve('../audioHandler')] = { exports: audioHandler };
+
+const reconnection = {
+    clearSessionParams: mock.fn(),
+    attemptReconnection: mock.fn(),
+};
+require.cache[require.resolve('../reconnection')] = { exports: reconnection };
+
+const sessionManager = {
+    initializeGeminiSession: mock.fn(),
+    sendImage: mock.fn(),
+    sendTextMessage: mock.fn(),
+};
+require.cache[require.resolve('../sessionManager')] = { exports: sessionManager };
+
+const conversationStore = {
+    getCurrentSessionData: mock.fn(() => ({})),
+    initializeNewSession: mock.fn(),
+    saveConversationTurn: mock.fn(),
+};
+require.cache[require.resolve('../conversationStore')] = { exports: conversationStore };
+
+const gemini = require('../gemini');
+
+test('initialize-gemini sets session reference on success', async () => {
+    handlers = {};
+    const geminiSessionRef = { current: null };
+    sessionManager.initializeGeminiSession = mock.fn(async () => ({ close: async () => {} }));
+    gemini.setupGeminiIpcHandlers(geminiSessionRef);
+
+    const result = await handlers['initialize-gemini']('k', '', 'p', 'en');
+
+    assert.strictEqual(result, true);
+    assert.ok(geminiSessionRef.current);
+});
+
+test('initialize-gemini returns false on failure', async () => {
+    handlers = {};
+    const geminiSessionRef = { current: null };
+    sessionManager.initializeGeminiSession = mock.fn(async () => null);
+    gemini.setupGeminiIpcHandlers(geminiSessionRef);
+
+    const result = await handlers['initialize-gemini']('k');
+
+    assert.strictEqual(result, false);
+    assert.strictEqual(geminiSessionRef.current, null);
+});
+
+test('close-session clears session and stops audio', async () => {
+    handlers = {};
+    audioHandler.stopMacOSAudioCapture = mock.fn();
+    reconnection.clearSessionParams = mock.fn();
+    const geminiSessionRef = { current: { close: mock.fn(async () => {}) } };
+    gemini.setupGeminiIpcHandlers(geminiSessionRef);
+
+    const result = await handlers['close-session']();
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(geminiSessionRef.current, null);
+    assert.strictEqual(audioHandler.stopMacOSAudioCapture.mock.callCount(), 1);
+    assert.strictEqual(reconnection.clearSessionParams.mock.callCount(), 1);
+});
+
+test('close-session handles close errors', async () => {
+    handlers = {};
+    audioHandler.stopMacOSAudioCapture = mock.fn();
+    reconnection.clearSessionParams = mock.fn();
+    const geminiSessionRef = { current: { close: mock.fn(async () => { throw new Error('boom'); }) } };
+    gemini.setupGeminiIpcHandlers(geminiSessionRef);
+
+    const result = await handlers['close-session']();
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error, 'boom');
+    assert.ok(geminiSessionRef.current);
+});

--- a/src/utils/__tests__/initializeGeminiSession.test.js
+++ b/src/utils/__tests__/initializeGeminiSession.test.js
@@ -1,0 +1,65 @@
+const { test, mock } = require('node:test');
+const assert = require('node:assert');
+
+// Mock ipcUtils to capture status updates
+const sendToRenderer = mock.fn();
+require.cache[require.resolve('../ipcUtils')] = { exports: { sendToRenderer } };
+
+// Mock reconnection module
+const reconnection = {
+    storeSessionParams: mock.fn(),
+    disableReconnection: mock.fn(),
+    attemptReconnection: mock.fn(),
+};
+require.cache[require.resolve('../reconnection')] = { exports: reconnection };
+
+// Mock conversationStore
+const conversationStore = {
+    initializeNewSession: mock.fn(),
+    saveConversationTurn: mock.fn(),
+    getConversationHistory: () => [],
+};
+require.cache[require.resolve('../conversationStore')] = { exports: conversationStore };
+
+// Mock GoogleGenAI client
+let callbacks;
+class FakeClient {
+    constructor() {}
+    get live() {
+        return {
+            connect: async ({ callbacks: cb }) => {
+                callbacks = cb;
+                return {
+                    close: async () => {},
+                    sendRealtimeInput: async () => {},
+                };
+            },
+        };
+    }
+}
+require.cache[require.resolve('@google/genai')] = { exports: { GoogleGenAI: FakeClient } };
+
+// Load sessionManager with mocks
+const sessionManager = require('../sessionManager');
+
+test('WebSocket onerror for invalid API key disables reconnection', async () => {
+    reconnection.disableReconnection = mock.fn();
+    const ref = { current: null };
+    await sessionManager.initializeGeminiSession(ref, 'key');
+
+    callbacks.onerror(new Error('API key not valid'));
+
+    assert.strictEqual(reconnection.disableReconnection.mock.callCount(), 1);
+    const lastStatus = sendToRenderer.mock.calls.at(-1).arguments;
+    assert.deepStrictEqual(lastStatus, ['update-status', 'Error: Invalid API key']);
+});
+
+test('WebSocket onclose triggers reconnection attempt', async () => {
+    reconnection.attemptReconnection = mock.fn();
+    const ref = { current: null };
+    await sessionManager.initializeGeminiSession(ref, 'key');
+
+    callbacks.onclose({ reason: 'network error' });
+
+    assert.strictEqual(reconnection.attemptReconnection.mock.callCount(), 1);
+});

--- a/src/utils/__tests__/reconnection.test.js
+++ b/src/utils/__tests__/reconnection.test.js
@@ -1,14 +1,16 @@
-const { test, beforeEach, mock } = require('node:test');
+const { test, mock } = require('node:test');
 const assert = require('node:assert');
+
+// Mock ipcUtils to capture status messages
+const sendToRenderer = mock.fn();
+require.cache[require.resolve('../ipcUtils')] = { exports: { sendToRenderer } };
+
 const reconnection = require('../reconnection');
 const conversationStore = require('../conversationStore');
 
-beforeEach(() => {
+test('attemptReconnection restores session and sends context', async () => {
     reconnection.clearSessionParams();
     conversationStore.initializeNewSession();
-});
-
-test('attemptReconnection restores session and sends context', async () => {
     reconnection.storeSessionParams({ apiKey: 'k', customPrompt: '', profile: 'p', language: 'en' });
     conversationStore.saveConversationTurn('question', 'answer');
     const sendRealtimeInput = mock.fn(async () => {});
@@ -20,4 +22,18 @@ test('attemptReconnection restores session and sends context', async () => {
     assert.ok(geminiSessionRef.current);
     assert.strictEqual(sendRealtimeInput.mock.callCount(), 1);
     assert.strictEqual(initializeSessionFn.mock.callCount(), 1);
+});
+
+test('attemptReconnection stops after errors and updates status', async () => {
+    reconnection.clearSessionParams();
+    conversationStore.initializeNewSession();
+    reconnection.storeSessionParams({ apiKey: 'k', customPrompt: '', profile: 'p', language: 'en' });
+    const geminiSessionRef = { current: null };
+    const initializeSessionFn = mock.fn(async () => { throw new Error('fail'); });
+    reconnection.__setReconnectionDelay(0);
+    const result = await reconnection.attemptReconnection(geminiSessionRef, initializeSessionFn);
+    assert.strictEqual(result, false);
+    assert.strictEqual(initializeSessionFn.mock.callCount(), 3);
+    const lastStatus = sendToRenderer.mock.calls.at(-1).arguments;
+    assert.deepStrictEqual(lastStatus, ['update-status', 'Session closed']);
 });


### PR DESCRIPTION
## Summary
- add unit tests for IPC handlers and WebSocket error paths
- mock Google and Electron APIs for isolated testing
- run tests in CI workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4cd0a09e48331b70d24bca40422a7