### PR TITLE
Persist and manage conversation history

### DIFF
--- a/src/utils/__tests__/conversationStore.test.js
+++ b/src/utils/__tests__/conversationStore.test.js
@@ -1,20 +1,57 @@
-const { test, beforeEach } = require('node:test');
+const { test } = require('node:test');
 const assert = require('node:assert');
-const conversationStore = require('../conversationStore');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
 
-beforeEach(() => {
-    conversationStore.initializeNewSession();
-});
+function loadStore(dir) {
+    const tmpDir = dir || fs.mkdtempSync(path.join(os.tmpdir(), 'cd-store-'));
+    process.env.APP_DATA_DIR = tmpDir;
+    delete require.cache[require.resolve('../conversationStore')];
+    const store = require('../conversationStore');
+    return { store, dir: tmpDir };
+}
 
 test('initializeNewSession creates new session with empty history', () => {
-    const data = conversationStore.getCurrentSessionData();
+    const { store } = loadStore();
+    store.initializeNewSession();
+    const data = store.getCurrentSessionData();
     assert.ok(data.sessionId);
     assert.deepStrictEqual(data.history, []);
 });
 
 test('saveConversationTurn stores turns', () => {
-    conversationStore.saveConversationTurn('hello', 'hi');
-    const data = conversationStore.getCurrentSessionData();
+    const { store } = loadStore();
+    store.initializeNewSession();
+    store.saveConversationTurn('hello', 'hi');
+    const data = store.getCurrentSessionData();
+    assert.strictEqual(data.history.length, 1);
+    assert.strictEqual(data.history[0].transcription, 'hello');
+});
+
+test('trims history to max length', () => {
+    const { store } = loadStore();
+    store.initializeNewSession();
+    store.setMaxHistoryLength(2);
+    store.saveConversationTurn('one', '1');
+    store.saveConversationTurn('two', '2');
+    store.saveConversationTurn('three', '3');
+    const data = store.getCurrentSessionData();
+    assert.strictEqual(data.history.length, 2);
+    assert.strictEqual(data.history[0].transcription, 'two');
+    assert.strictEqual(data.history[1].transcription, 'three');
+});
+
+test('persists history to disk and reloads', () => {
+    const { store, dir } = loadStore();
+    store.initializeNewSession();
+    store.saveConversationTurn('hello', 'hi');
+    const sessionId = store.getCurrentSessionData().sessionId;
+    delete require.cache[require.resolve('../conversationStore')];
+    process.env.APP_DATA_DIR = dir;
+    const reloadedStore = require('../conversationStore');
+    const data = reloadedStore.getCurrentSessionData();
+    assert.strictEqual(data.sessionId, sessionId);
     assert.strictEqual(data.history.length, 1);
     assert.strictEqual(data.history[0].transcription, 'hello');
 });

--- a/src/utils/__tests__/reconnection.test.js
+++ b/src/utils/__tests__/reconnection.test.js
@@ -1,7 +1,13 @@
 const { test, beforeEach, mock } = require('node:test');
 const assert = require('node:assert');
-const reconnection = require('../reconnection');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cd-reconnect-'));
+process.env.APP_DATA_DIR = tmpDir;
 const conversationStore = require('../conversationStore');
+const reconnection = require('../reconnection');
 
 beforeEach(() => {
     reconnection.clearSessionParams();

--- a/src/utils/conversationStore.js
+++ b/src/utils/conversationStore.js
@@ -1,11 +1,68 @@
 const { sendToRenderer } = require('./ipcUtils');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
 let currentSessionId = null;
 let conversationHistory = [];
+let maxHistoryLength = 100;
+
+function setMaxHistoryLength(length) {
+    const parsed = parseInt(length, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+        maxHistoryLength = parsed;
+    }
+}
+
+let historyFilePath = null;
+
+function getHistoryFilePath() {
+    if (!historyFilePath) {
+        let dir;
+        if (process.env.APP_DATA_DIR) {
+            dir = process.env.APP_DATA_DIR;
+        } else {
+            try {
+                const { app } = require('electron');
+                dir = app.getPath('userData');
+            } catch {
+                dir = path.join(os.tmpdir(), 'cheating-daddy');
+            }
+        }
+        fs.mkdirSync(dir, { recursive: true });
+        historyFilePath = path.join(dir, 'conversation-history.json');
+    }
+    return historyFilePath;
+}
+
+function persistHistory() {
+    try {
+        const data = { sessionId: currentSessionId, history: conversationHistory };
+        fs.writeFileSync(getHistoryFilePath(), JSON.stringify(data, null, 2));
+    } catch (err) {
+        console.error('Failed to persist conversation history:', err);
+    }
+}
+
+function loadHistory() {
+    try {
+        const file = getHistoryFilePath();
+        if (fs.existsSync(file)) {
+            const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+            currentSessionId = data.sessionId || null;
+            conversationHistory = Array.isArray(data.history) ? data.history : [];
+        }
+    } catch (err) {
+        console.error('Failed to load conversation history:', err);
+        currentSessionId = null;
+        conversationHistory = [];
+    }
+}
 
 function initializeNewSession() {
     currentSessionId = Date.now().toString();
     conversationHistory = [];
+    persistHistory();
     console.log('New conversation session started:', currentSessionId);
     return currentSessionId;
 }
@@ -22,6 +79,10 @@ function saveConversationTurn(transcription, aiResponse) {
     };
 
     conversationHistory.push(conversationTurn);
+    if (conversationHistory.length > maxHistoryLength) {
+        conversationHistory = conversationHistory.slice(-maxHistoryLength);
+    }
+    persistHistory();
     console.log('Saved conversation turn:', conversationTurn);
 
     sendToRenderer('save-conversation-turn', {
@@ -42,9 +103,27 @@ function getConversationHistory() {
     return conversationHistory;
 }
 
+function exportConversationHistory() {
+    return { sessionId: currentSessionId, history: conversationHistory };
+}
+
+function clearConversationHistory() {
+    currentSessionId = null;
+    conversationHistory = [];
+    try {
+        fs.rmSync(getHistoryFilePath(), { force: true });
+    } catch {}
+    sendToRenderer('history-cleared');
+}
+
+loadHistory();
+
 module.exports = {
     initializeNewSession,
     saveConversationTurn,
     getCurrentSessionData,
     getConversationHistory,
+    setMaxHistoryLength,
+    exportConversationHistory,
+    clearConversationHistory,
 };

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -98,6 +98,25 @@ function setupGeminiIpcHandlers(geminiSessionRef) {
         }
     });
 
+    ipcMain.handle('export-conversation-history', async () => {
+        try {
+            return { success: true, data: conversationStore.exportConversationHistory() };
+        } catch (error) {
+            console.error('Error exporting conversation history:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
+    ipcMain.handle('clear-conversation-history', async () => {
+        try {
+            conversationStore.clearConversationHistory();
+            return { success: true };
+        } catch (error) {
+            console.error('Error clearing conversation history:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
     ipcMain.handle('update-google-search-setting', async enabled => {
         try {
             console.log('Google Search setting updated to:', enabled);
@@ -119,6 +138,8 @@ module.exports = {
     initializeNewSession: conversationStore.initializeNewSession,
     saveConversationTurn: conversationStore.saveConversationTurn,
     getCurrentSessionData: conversationStore.getCurrentSessionData,
+    exportConversationHistory: conversationStore.exportConversationHistory,
+    clearConversationHistory: conversationStore.clearConversationHistory,
     sendReconnectionContext: reconnection.sendReconnectionContext,
     killExistingSystemAudioDump: audioHandler.killExistingSystemAudioDump,
     startMacOSAudioCapture: audioHandler.startMacOSAudioCapture,


### PR DESCRIPTION
## Summary
- add disk-backed conversation history with configurable max size
- expose IPC handlers to export or clear history
- test history trimming and persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4cd0cded08331a0a569bcd9ea6c3d