### PR TITLE
feat: dynamic title via APP_NAME

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -2,7 +2,9 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Cheating Daddy</title>
+    <script>
+      document.title = process.env.APP_NAME || 'Sales Wizard';
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig(() => ({
+  define: {
+    'process.env.APP_NAME': JSON.stringify(process.env.APP_NAME),
+  },
+}));


### PR DESCRIPTION
## Summary
- Set desktop index title from `APP_NAME` env with fallback to Sales Wizard
- Define `process.env.APP_NAME` in Vite so renderer can access it

## Testing
- `npm test`
- `npm run lint`
- `cd apps/desktop && npm test`
- `cd apps/desktop && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bae180d7c48331a63cde1ddaefead7