### PR TITLE
chore: rename app to Sales Wizard

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -5,7 +5,7 @@ module.exports = {
     packagerConfig: {
         asar: true,
         extraResource: ['./src/assets/SystemAudioDump'],
-        name: 'Cheating Daddy',
+        name: process.env.APP_NAME || 'Sales Wizard',
         icon: 'src/assets/logo',
         // use `security find-identity -v -p codesigning` to find your identity
         // for macos signing
@@ -30,9 +30,9 @@ module.exports = {
         {
             name: '@electron-forge/maker-squirrel',
             config: {
-                name: 'cheating-daddy',
-                productName: 'Cheating Daddy',
-                shortcutName: 'Cheating Daddy',
+                name: 'sales-wizard',
+                productName: 'Sales Wizard',
+                shortcutName: 'Sales Wizard',
                 createDesktopShortcut: true,
                 createStartMenuShortcut: true,
             },
@@ -46,13 +46,13 @@ module.exports = {
             platforms: ['linux'],
             config: {
                 options: {
-                    name: 'Cheating Daddy',
-                    productName: 'Cheating Daddy',
+                    name: 'Sales Wizard',
+                    productName: 'Sales Wizard',
                     genericName: 'AI Assistant',
                     description: 'AI assistant for interviews and learning',
                     categories: ['Development', 'Education'],
-                    icon: 'src/assets/logo.png'
-                }
+                    icon: 'src/assets/logo.png',
+                },
             },
         },
     ],


### PR DESCRIPTION
## Summary
- rename forge config from Cheating Daddy to Sales Wizard
- allow overriding app name via APP_NAME env variable

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bae1823c448331a83dd9c5f8129a8f