### PR TITLE
feat: expose app name configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Copy to .env and fill in your configuration
+APP_NAME=Sales Wizard
 GEMINI_API_KEY=your_api_key_here
 PORT=3001

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,12 @@
 if (require('electron-squirrel-startup')) {
     process.exit(0);
 }
-require("./utils/logger");
+
+require('dotenv').config();
+require('./utils/logger');
 
 const { app, BrowserWindow, shell, ipcMain, screen } = require('electron');
+const { getAppName } = require('./utils/config');
 const { createWindow, updateGlobalShortcuts } = require('./utils/window');
 const { setupGeminiIpcHandlers, stopMacOSAudioCapture, sendToRenderer } = require('./utils/gemini');
 const { registerSecureStoreIpc } = require('./utils/secureStore');
@@ -12,6 +15,8 @@ const { applyAntiAnalysisMeasures } = require('./utils/stealthFeatures');
 
 const geminiSessionRef = { current: null };
 let mainWindow = null;
+
+app.setName(getAppName());
 
 // Initialize random process names for stealth
 const randomNames = initializeRandomProcessNames();

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,4 +1,5 @@
 const { contextBridge, ipcRenderer } = require('electron');
+const config = require('./utils/config');
 
 const ipc = {
     invoke: (channel, ...args) => ipcRenderer.invoke(channel, ...args),
@@ -10,3 +11,5 @@ const ipc = {
 };
 
 contextBridge.exposeInMainWorld('electron', { ipcRenderer: ipc });
+contextBridge.exposeInMainWorld('env', { ...process.env });
+contextBridge.exposeInMainWorld('config', config);

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,0 +1,43 @@
+/**
+ * Utility helpers for accessing configuration values across
+ * both the main and renderer processes.
+ */
+
+function getEnvVar(key, defaultValue) {
+    if (
+        typeof process !== 'undefined' &&
+        process.env &&
+        Object.prototype.hasOwnProperty.call(process.env, key)
+    ) {
+        return process.env[key];
+    }
+    if (
+        typeof window !== 'undefined' &&
+        window.env &&
+        Object.prototype.hasOwnProperty.call(window.env, key)
+    ) {
+        return window.env[key];
+    }
+    return defaultValue;
+}
+
+function getAppName() {
+    return getEnvVar('APP_NAME', 'Sales Wizard');
+}
+
+function getPort() {
+    const port = getEnvVar('PORT', '3001');
+    return Number(port);
+}
+
+function getGeminiApiKey() {
+    return getEnvVar('GEMINI_API_KEY');
+}
+
+module.exports = {
+    getEnvVar,
+    getAppName,
+    getPort,
+    getGeminiApiKey,
+};
+

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -1,6 +1,11 @@
 // renderer.js
 const { ipcRenderer } = window.electron || {};
 
+const appName = window.config?.getAppName();
+if (appName) {
+    document.title = appName;
+}
+
 // Initialize random display name for UI components
 window.randomDisplayName = null;
 


### PR DESCRIPTION
## Summary
- add APP_NAME to sample env file
- centralize config helpers for accessing env vars
- load APP_NAME in main process and expose to renderer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bae18605dc83319f163be73549f149