### PR TITLE
feat: add live capture IPC handlers

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -1,4 +1,66 @@
-const { contextBridge, ipcRenderer } = require('electron');
+const { contextBridge, ipcRenderer, ipcMain } = require('electron');
+const { startAudioCapture, startScreenCapture } = require('./services/liveCapture');
+const LiveSession = require('./services/liveSession');
+
+// Maintain active live sessions for cleanup and data forwarding
+const liveSessions = new Map();
+
+ipcMain.handle('live-open', async (_event, sessionId) => {
+    const id = sessionId || Date.now().toString();
+    const session = new LiveSession(id);
+    liveSessions.set(id, session);
+    return { success: true, sessionId: id };
+});
+
+ipcMain.handle('audio-start', async (_event, sessionId, options) => {
+    const session = sessionId ? liveSessions.get(sessionId) : liveSessions.values().next().value;
+    if (!session) {
+        return { success: false, error: 'Invalid session' };
+    }
+    return startAudioCapture(session, options);
+});
+
+ipcMain.handle('screen-start', async (_event, sessionId, options) => {
+    const session = sessionId ? liveSessions.get(sessionId) : liveSessions.values().next().value;
+    if (!session) {
+        return { success: false, error: 'Invalid session' };
+    }
+    return startScreenCapture(session, options);
+});
+
+ipcMain.handle('live-send-audio', async (_event, sessionIdOrData, maybeData) => {
+    let session;
+    let data;
+    if (maybeData === undefined && typeof sessionIdOrData === 'object') {
+        data = sessionIdOrData;
+        session = liveSessions.values().next().value;
+    } else {
+        session = sessionIdOrData ? liveSessions.get(sessionIdOrData) : liveSessions.values().next().value;
+        data = maybeData;
+    }
+    if (!session) {
+        return { success: false, error: 'Invalid session' };
+    }
+    await session.sendAudio(data);
+    return { success: true };
+});
+
+ipcMain.handle('live-send-image', async (_event, sessionIdOrData, maybeData) => {
+    let session;
+    let data;
+    if (maybeData === undefined && typeof sessionIdOrData === 'object') {
+        data = sessionIdOrData;
+        session = liveSessions.values().next().value;
+    } else {
+        session = sessionIdOrData ? liveSessions.get(sessionIdOrData) : liveSessions.values().next().value;
+        data = maybeData;
+    }
+    if (!session) {
+        return { success: false, error: 'Invalid session' };
+    }
+    await session.sendImage(data);
+    return { success: true };
+});
 
 const ipc = {
     invoke: (channel, ...args) => ipcRenderer.invoke(channel, ...args),

--- a/src/services/liveCapture.js
+++ b/src/services/liveCapture.js
@@ -1,0 +1,11 @@
+async function startAudioCapture(_session, _options = {}) {
+    // Placeholder implementation for starting audio capture
+    return { success: true };
+}
+
+async function startScreenCapture(_session, _options = {}) {
+    // Placeholder implementation for starting screen capture
+    return { success: true };
+}
+
+module.exports = { startAudioCapture, startScreenCapture };

--- a/src/services/liveSession.js
+++ b/src/services/liveSession.js
@@ -1,0 +1,22 @@
+class LiveSession {
+    constructor(id) {
+        this.id = id;
+    }
+
+    async sendAudio(_data) {
+        // Placeholder for sending audio data to the session
+        return true;
+    }
+
+    async sendImage(_data) {
+        // Placeholder for sending image data to the session
+        return true;
+    }
+
+    async close() {
+        // Placeholder for cleaning up session resources
+        return true;
+    }
+}
+
+module.exports = LiveSession;


### PR DESCRIPTION
## Summary
- manage live sessions via new IPC handlers
- forward audio and image through `live-send-*` channels
- scaffold live capture helpers for sessions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bae189a7c48331a703f4cf5d8860ec