### PR TITLE
feat: add configurable context parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,11 @@ const { applyAntiAnalysisMeasures } = require('./utils/stealthFeatures');
 
 const geminiSessionRef = { current: null };
 let mainWindow = null;
+let contextParams = {
+    allowedSources: '',
+    toneLength: '',
+    disallowedTopics: '',
+};
 
 // Initialize random process names for stealth
 const randomNames = initializeRandomProcessNames();
@@ -98,6 +103,15 @@ function setupGeneralIpcHandlers() {
             logger.error('Error getting random display name:', error);
             return 'System Monitor';
         }
+    });
+
+    ipcMain.handle('set-context-params', async (_event, params) => {
+        contextParams = { ...contextParams, ...params };
+        return { success: true };
+    });
+
+    ipcMain.handle('get-context-params', async () => {
+        return { success: true, data: contextParams };
     });
 
     // Provide cursor position and display bounds for region screenshots

--- a/src/services/llmClient.js
+++ b/src/services/llmClient.js
@@ -40,11 +40,12 @@ export class LLMClient {
                 this.ws.onopen = () => {
                     opened = true;
                     clearTimeout(timeout);
+                    const instr = systemInstruction || this._buildSystemInstruction();
                     this._send({
                         type: 'start',
                         model,
                         responseModalities,
-                        systemInstruction,
+                        systemInstruction: instr,
                     });
                     this.onStatus('WS open');
                     resolve(true);
@@ -81,6 +82,22 @@ export class LLMClient {
                 reject(e);
             }
         });
+    }
+
+    _buildSystemInstruction() {
+        try {
+            if (typeof localStorage === 'undefined') return undefined;
+            const allowedSources = localStorage.getItem('contextAllowedSources') || '';
+            const toneLength = localStorage.getItem('contextToneLength') || '';
+            const disallowedTopics = localStorage.getItem('contextDisallowedTopics') || '';
+            const parts = [];
+            if (allowedSources) parts.push(`Allowed sources: ${allowedSources}.`);
+            if (toneLength) parts.push(`Tone/Length: ${toneLength}.`);
+            if (disallowedTopics) parts.push(`Disallowed topics: ${disallowedTopics}.`);
+            return parts.join(' ');
+        } catch (e) {
+            return undefined;
+        }
     }
 
     _send(obj) {

--- a/src/utils/prompts.js
+++ b/src/utils/prompts.js
@@ -201,7 +201,7 @@ Provide direct exam answers in **markdown format**. Include the question text, t
     },
 };
 
-function buildSystemPrompt(promptParts, customPrompt = '', googleSearchEnabled = true) {
+function buildSystemPrompt(promptParts, customPrompt = '', googleSearchEnabled = true, contextParams = {}) {
     const sections = [promptParts.intro, '\n\n', promptParts.formatRequirements];
 
     // Only add search usage section if Google Search is enabled
@@ -209,14 +209,27 @@ function buildSystemPrompt(promptParts, customPrompt = '', googleSearchEnabled =
         sections.push('\n\n', promptParts.searchUsage);
     }
 
+    if (contextParams.allowedSources || contextParams.toneLength || contextParams.disallowedTopics) {
+        sections.push('\n\n**CONTEXT PARAMETERS:**');
+        if (contextParams.allowedSources) {
+            sections.push(`\n- Allowed sources: ${contextParams.allowedSources}`);
+        }
+        if (contextParams.toneLength) {
+            sections.push(`\n- Tone/Length: ${contextParams.toneLength}`);
+        }
+        if (contextParams.disallowedTopics) {
+            sections.push(`\n- Disallowed topics: ${contextParams.disallowedTopics}`);
+        }
+    }
+
     sections.push('\n\n', promptParts.content, '\n\nUser-provided context\n-----\n', customPrompt, '\n-----\n\n', promptParts.outputInstructions);
 
     return sections.join('');
 }
 
-function getSystemPrompt(profile, customPrompt = '', googleSearchEnabled = true) {
+function getSystemPrompt(profile, customPrompt = '', googleSearchEnabled = true, contextParams = {}) {
     const promptParts = profilePrompts[profile] || profilePrompts.interview;
-    return buildSystemPrompt(promptParts, customPrompt, googleSearchEnabled);
+    return buildSystemPrompt(promptParts, customPrompt, googleSearchEnabled, contextParams);
 }
 
 module.exports = {

--- a/src/utils/sessionManager.js
+++ b/src/utils/sessionManager.js
@@ -69,7 +69,12 @@ async function initializeGeminiSession(
     const client = new GoogleGenAI({ vertexai: false, apiKey });
     const enabledTools = await getEnabledTools();
     const googleSearchEnabled = enabledTools.some(tool => tool.googleSearch);
-    const systemPrompt = getSystemPrompt(profile, customPrompt, googleSearchEnabled);
+    const contextParams = {
+        allowedSources: await module.exports.getStoredSetting('contextAllowedSources', ''),
+        toneLength: await module.exports.getStoredSetting('contextToneLength', ''),
+        disallowedTopics: await module.exports.getStoredSetting('contextDisallowedTopics', ''),
+    };
+    const systemPrompt = getSystemPrompt(profile, customPrompt, googleSearchEnabled, contextParams);
 
     if (!isReconnection) {
         conversationStore.initializeNewSession();


### PR DESCRIPTION
## Summary
- add configurable context parameters to frontend with persistence and IPC
- expose context parameters in backend and inject into Gemini requests
- apply context filters to prompt generation and WebSocket client

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb14b164948331b24060e7a9af2f8d