### PR TITLE
feat: add whitelist validation middleware

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -8,7 +8,58 @@ const app = express();
 app.use(express.json());
 const genai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
 
-app.post('/ask', async (req, res) => {
+// In-memory whitelist of allowed resource domains/documents
+const whitelist = new Set(
+  (process.env.WHITELIST || '')
+    .split(',')
+    .map(d => d.trim())
+    .filter(Boolean)
+);
+
+// Middleware to validate requested resources against the whitelist
+function validateResources(req, res, next) {
+  const resources = Array.isArray(req.body?.resources) ? req.body.resources : [];
+  const invalid = [];
+
+  for (const urlStr of resources) {
+    try {
+      const url = new URL(urlStr);
+      const allowed = Array.from(whitelist).some(domain =>
+        url.hostname === domain || url.hostname.endsWith(`.${domain}`)
+      );
+      if (!allowed) invalid.push(urlStr);
+    } catch (_e) {
+      // Malformed URLs are considered invalid
+      invalid.push(urlStr);
+    }
+  }
+
+  if (invalid.length > 0) {
+    return res.status(400).json({ error: 'Resource not permitted', invalid });
+  }
+  next();
+}
+
+// Whitelist management endpoints
+app.get('/context/whitelist', (_req, res) => {
+  res.json({ whitelist: Array.from(whitelist) });
+});
+
+app.post('/context/whitelist', (req, res) => {
+  const { whitelist: list } = req.body || {};
+  if (!Array.isArray(list)) {
+    return res.status(400).json({ error: 'Whitelist must be an array of domains' });
+  }
+  whitelist.clear();
+  for (const item of list) {
+    if (typeof item === 'string' && item.trim()) {
+      whitelist.add(item.trim());
+    }
+  }
+  res.json({ whitelist: Array.from(whitelist) });
+});
+
+app.post('/ask', validateResources, async (req, res) => {
   const prompt = req.body.prompt || '';
   try {
     const model = genai.getGenerativeModel({ model: 'gemini-pro' });


### PR DESCRIPTION
## Summary
- add in-memory whitelist with REST endpoints
- validate incoming resource requests against whitelist before Gemini calls
- expose context params UI for whitelist editing and validation feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb14b329348331bd62c37ae90f11b2