### PR TITLE
Add backend tests and offline retry for conversation turns

### DIFF
--- a/backend/__tests__/server.test.js
+++ b/backend/__tests__/server.test.js
@@ -1,0 +1,44 @@
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const request = require('supertest');
+const { app, sessions, contextParams } = require('../server');
+
+beforeEach(() => {
+  for (const key of Object.keys(sessions)) delete sessions[key];
+  for (const key of Object.keys(contextParams)) delete contextParams[key];
+});
+
+test('saving turns and retrieving transcripts', async () => {
+  await request(app)
+    .post('/sessions/123/turns')
+    .send({ transcription: 'hi', ai_response: 'hello' })
+    .expect(201);
+
+  const res = await request(app)
+    .get('/sessions/123/transcript')
+    .expect(200);
+  assert.deepStrictEqual(res.body.transcript, [{ transcription: 'hi', ai_response: 'hello' }]);
+});
+
+test('creating/updating context parameters and enforcing source restrictions', async () => {
+  await request(app)
+    .put('/context/foo')
+    .send({ value: 'bar', source: 'user' })
+    .expect(200);
+
+  await request(app)
+    .put('/context/foo')
+    .send({ value: 'baz', source: 'user' })
+    .expect(200);
+
+  const res = await request(app)
+    .put('/context/foo')
+    .send({ value: 'hack', source: 'system' })
+    .expect(403);
+  assert.strictEqual(res.body.error, 'Source mismatch');
+
+  const final = await request(app)
+    .get('/context/foo')
+    .expect(200);
+  assert.strictEqual(final.body.value, 'baz');
+});

--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,44 @@ const app = express();
 app.use(express.json());
 const genai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
 
+// In-memory stores for tests/demo
+const sessions = {};
+const contextParams = {};
+
+// Conversation turn endpoints
+app.post('/sessions/:sessionId/turns', (req, res) => {
+  const { sessionId } = req.params;
+  const { transcription = '', ai_response = '' } = req.body || {};
+  sessions[sessionId] = sessions[sessionId] || [];
+  sessions[sessionId].push({ transcription, ai_response });
+  res.status(201).json({ ok: true });
+});
+
+app.get('/sessions/:sessionId/transcript', (req, res) => {
+  const { sessionId } = req.params;
+  res.json({ transcript: sessions[sessionId] || [] });
+});
+
+// Context parameter endpoints with source restrictions
+app.put('/context/:name', (req, res) => {
+  const { name } = req.params;
+  const { value, source } = req.body || {};
+  if (!value || !source) return res.status(400).json({ error: 'Missing fields' });
+  const existing = contextParams[name];
+  if (existing && existing.source !== source) {
+    return res.status(403).json({ error: 'Source mismatch' });
+  }
+  contextParams[name] = { value, source };
+  res.json(contextParams[name]);
+});
+
+app.get('/context/:name', (req, res) => {
+  const param = contextParams[req.params.name];
+  if (!param) return res.status(404).json({ error: 'Not found' });
+  res.json(param);
+});
+
+// Ask endpoint remains for completeness
 app.post('/ask', async (req, res) => {
   const prompt = req.body.prompt || '';
   try {
@@ -21,33 +59,40 @@ app.post('/ask', async (req, res) => {
   }
 });
 
-const server = app.listen(process.env.PORT || 3001);
+function startServer(port = process.env.PORT || 3001) {
+  const server = app.listen(port);
+  const wss = new WebSocketServer({ server, path: '/live' });
+  wss.on('connection', async (ws) => {
+    const session = await genai.live.connect({
+      model: 'gemini-live-2.5-flash-preview',
+      config: { response_modalities: [Modality.TEXT], system_instruction: 'You are a helpful assistant.' }
+    });
 
-// WebSocket endpoint for Gemini Live
-const wss = new WebSocketServer({ server, path: '/live' });
-wss.on('connection', async (ws) => {
-  const session = await genai.live.connect({
-    model: 'gemini-live-2.5-flash-preview',
-    config: { response_modalities: [Modality.TEXT], system_instruction: 'You are a helpful assistant.' }
+    // Forward Gemini replies back to the client
+    (async () => {
+      for await (const response of session.receive()) {
+        ws.send(JSON.stringify({ text: response.text || '' }));
+      }
+    })();
+
+    ws.on('message', async (msg) => {
+      const data = JSON.parse(msg);
+      if (data.audio) {
+        const buf = Buffer.from(data.audio, 'base64');
+        await session.send_realtime_input({ audio: { data: buf, mime_type: data.mimeType || 'audio/pcm;rate=16000' } });
+      } else if (data.image) {
+        const buf = Buffer.from(data.image, 'base64');
+        await session.send_realtime_input({ image: { data: buf, mime_type: data.mimeType || 'image/jpeg' } });
+      }
+    });
+
+    ws.on('close', () => session.close());
   });
+  return server;
+}
 
-  // Forward Gemini replies back to the client
-  (async () => {
-    for await (const response of session.receive()) {
-      ws.send(JSON.stringify({ text: response.text || '' }));
-    }
-  })();
+if (require.main === module) {
+  startServer();
+}
 
-  ws.on('message', async (msg) => {
-    const data = JSON.parse(msg);
-    if (data.audio) {
-      const buf = Buffer.from(data.audio, 'base64');
-      await session.send_realtime_input({ audio: { data: buf, mime_type: data.mimeType || 'audio/pcm;rate=16000' } });
-    } else if (data.image) {
-      const buf = Buffer.from(data.image, 'base64');
-      await session.send_realtime_input({ image: { data: buf, mime_type: data.mimeType || 'image/jpeg' } });
-    }
-  });
-
-  ws.on('close', () => session.close());
-});
+module.exports = { app, sessions, contextParams, startServer };

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "concurrently": "^8.2.2",
         "electron": "^30.0.5",
         "eslint": "^8.57.1",
-        "prettier": "^3.6.2"
+        "prettier": "^3.6.2",
+        "supertest": "^6.3.3"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1640,6 +1641,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1705,6 +1719,16 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@reforged/maker-appimage": {
@@ -2102,6 +2126,13 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -2109,6 +2140,13 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2725,6 +2763,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
@@ -2743,6 +2794,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/concat-map": {
@@ -2830,6 +2891,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -3021,6 +3089,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3056,6 +3134,17 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/dir-compare": {
       "version": "4.2.0",
@@ -4048,6 +4137,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
@@ -4607,6 +4712,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4786,6 +4898,39 @@
       "optional": true,
       "dependencies": {
         "imul": "^1.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -5377,6 +5522,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -8469,6 +8630,82 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "make": "electron-forge make",
     "publish": "electron-forge publish",
     "lint": "eslint .",
-    "test": "node -r ./src/utils/logger.js --test src/utils/__tests__/*.test.js",
+    "test": "node -r ./src/utils/logger.js --test src/utils/__tests__ backend/__tests__",
     "format": "prettier --write ."
   },
   "keywords": [
@@ -50,6 +50,7 @@
     "concurrently": "^8.2.2",
     "electron": "^30.0.5",
     "eslint": "^8.57.1",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "supertest": "^6.3.3"
   }
 }

--- a/src/utils/__tests__/conversationStore.test.js
+++ b/src/utils/__tests__/conversationStore.test.js
@@ -1,9 +1,17 @@
-const { test, beforeEach } = require('node:test');
+const { test, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
 const conversationStore = require('../conversationStore');
 
+let originalFetch;
+
 beforeEach(() => {
     conversationStore.initializeNewSession();
+    conversationStore.__clearPendingTurns();
+    originalFetch = global.fetch;
+});
+
+afterEach(() => {
+    global.fetch = originalFetch;
 });
 
 test('initializeNewSession creates new session with empty history', () => {
@@ -17,4 +25,37 @@ test('saveConversationTurn stores turns', () => {
     const data = conversationStore.getCurrentSessionData();
     assert.strictEqual(data.history.length, 1);
     assert.strictEqual(data.history[0].transcription, 'hello');
+});
+
+test('sends turns to backend', async () => {
+    const calls = [];
+    global.fetch = async (url, opts) => {
+        calls.push({ url, opts });
+        return { ok: true };
+    };
+    conversationStore.saveConversationTurn('question', 'answer');
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(calls.length, 1);
+    const body = JSON.parse(calls[0].opts.body);
+    assert.strictEqual(body.transcription, 'question');
+    assert.strictEqual(body.ai_response, 'answer');
+});
+
+test('retries pending turns when offline', async () => {
+    let fail = true;
+    const calls = [];
+    global.fetch = async (url, opts) => {
+        calls.push({ url, opts });
+        if (fail) throw new Error('offline');
+        return { ok: true };
+    };
+
+    conversationStore.saveConversationTurn('q1', 'a1');
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(conversationStore.__getPendingTurns().length, 1);
+
+    fail = false;
+    await conversationStore.retryPendingTurns();
+    assert.strictEqual(conversationStore.__getPendingTurns().length, 0);
+    assert.strictEqual(calls.length, 2);
 });

--- a/src/utils/conversationStore.js
+++ b/src/utils/conversationStore.js
@@ -2,6 +2,7 @@ const { sendToRenderer } = require('./ipcUtils');
 
 let currentSessionId = null;
 let conversationHistory = [];
+let pendingTurns = [];
 
 function initializeNewSession() {
     currentSessionId = Date.now().toString();
@@ -29,6 +30,9 @@ function saveConversationTurn(transcription, aiResponse) {
         turn: conversationTurn,
         fullHistory: conversationHistory,
     });
+
+    // Attempt to send to backend, queue on failure
+    sendTurnToBackend(currentSessionId, conversationTurn);
 }
 
 function getCurrentSessionData() {
@@ -42,9 +46,50 @@ function getConversationHistory() {
     return conversationHistory;
 }
 
+async function sendTurnToBackend(sessionId, turn) {
+    try {
+        await fetch(`http://localhost:3001/sessions/${sessionId}/turns`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(turn),
+        });
+    } catch (error) {
+        logger.error('Failed to send conversation turn:', error);
+        pendingTurns.push({ sessionId, turn });
+    }
+}
+
+async function retryPendingTurns() {
+    const queue = [...pendingTurns];
+    pendingTurns = [];
+    for (const { sessionId, turn } of queue) {
+        try {
+            await fetch(`http://localhost:3001/sessions/${sessionId}/turns`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(turn),
+            });
+        } catch (error) {
+            logger.error('Retry failed for conversation turn:', error);
+            pendingTurns.push({ sessionId, turn });
+        }
+    }
+}
+
+function __getPendingTurns() {
+    return pendingTurns;
+}
+
+function __clearPendingTurns() {
+    pendingTurns = [];
+}
+
 module.exports = {
     initializeNewSession,
     saveConversationTurn,
     getCurrentSessionData,
     getConversationHistory,
+    retryPendingTurns,
+    __getPendingTurns,
+    __clearPendingTurns,
 };


### PR DESCRIPTION
## Summary
- send conversation turns to backend and queue retries when offline
- add backend endpoints for turns, transcripts, and restricted context parameters
- cover conversationStore and backend HTTP flows with new tests and supertest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb14b47b488331b42f12c3c13a6218