### PR TITLE
feat: record session transcripts and notes

### DIFF
--- a/src/utils/screenCapture.js
+++ b/src/utils/screenCapture.js
@@ -1,3 +1,4 @@
+/* global MediaStreamTrackProcessor */
 export async function startScreenCapture({ quality = 'medium', cropRegion = 'full' } = {}) {
   // Track cursor position when needed for cropping
   let lastCursorPoint = null;


### PR DESCRIPTION
## Summary
- Track session metadata including transcripts and notes with unique session IDs
- Post turns and notes to history endpoint and render side panel alongside assistant view
- Define MediaStreamTrackProcessor global for screen capture linting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bce5d7dce08331906dd0d6b758c41e