### PR TITLE
Add tests for history notes and support in history store

### DIFF
--- a/backend/historyStore.js
+++ b/backend/historyStore.js
@@ -41,11 +41,16 @@ function appendTurn(sessionId, data) {
             id: sessionId,
             timestamp: data.timestamp || Date.now(),
             conversationHistory: [],
+            notes: data.notes || '',
         };
         history.sessions[sessionId] = session;
     }
 
-    if (!data.sessionStart) {
+    if (typeof data.notes === 'string') {
+        session.notes = data.notes;
+    }
+
+    if (!data.sessionStart && (data.transcription || data.ai_response)) {
         session.conversationHistory.push({
             timestamp: data.timestamp || Date.now(),
             transcription: data.transcription || '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "concurrently": "^8.2.2",
         "electron": "^30.0.5",
         "eslint": "^8.57.1",
+        "mock-fs": "^5.5.0",
         "prettier": "^3.6.2"
       }
     },
@@ -6743,6 +6744,16 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
+    },
+    "node_modules/mock-fs": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.5.0.tgz",
+      "integrity": "sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@google/genai": "^1.2.0",
+    "active-win": "^8.0.0",
     "dotenv": "^16.4.5",
     "electron-squirrel-startup": "^1.0.1",
     "express": "^4.19.2",
     "keytar": "^7.9.0",
     "tesseract.js": "^4.0.3",
-    "ws": "^8.16.0",
-    "active-win": "^8.0.0"
+    "ws": "^8.16.0"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.8.1",
@@ -51,6 +51,7 @@
     "concurrently": "^8.2.2",
     "electron": "^30.0.5",
     "eslint": "^8.57.1",
+    "mock-fs": "^5.5.0",
     "prettier": "^3.6.2"
   }
 }

--- a/src/utils/__tests__/historyStore.notes.test.js
+++ b/src/utils/__tests__/historyStore.notes.test.js
@@ -1,0 +1,44 @@
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const mockFs = require('mock-fs');
+const path = require('path');
+
+const historyStore = require('../../../backend/historyStore');
+const historyFile = path.join(__dirname, '../../../backend/history.json');
+
+beforeEach(() => {
+    mockFs({ [historyFile]: JSON.stringify({ sessions: {} }) });
+});
+
+afterEach(() => {
+    mockFs.restore();
+});
+
+test('Starting a session with sessionStart: true', () => {
+    const sessionId = 'session-start';
+    historyStore.appendTurn(sessionId, { sessionStart: true });
+    const session = historyStore.getSession(sessionId);
+    assert.ok(session);
+    assert.deepStrictEqual(session.conversationHistory, []);
+});
+
+test('Updating notes independently', () => {
+    const sessionId = 'notes-update';
+    historyStore.appendTurn(sessionId, { sessionStart: true });
+    historyStore.appendTurn(sessionId, { notes: 'First note' });
+    let session = historyStore.getSession(sessionId);
+    assert.strictEqual(session.notes, 'First note');
+    historyStore.appendTurn(sessionId, { notes: 'Updated note' });
+    session = historyStore.getSession(sessionId);
+    assert.strictEqual(session.notes, 'Updated note');
+    assert.strictEqual(session.conversationHistory.length, 0);
+});
+
+test('getSession returns the latest notes', () => {
+    const sessionId = 'latest-notes';
+    historyStore.appendTurn(sessionId, { sessionStart: true });
+    historyStore.appendTurn(sessionId, { notes: 'Old note' });
+    historyStore.appendTurn(sessionId, { notes: 'New note' });
+    const session = historyStore.getSession(sessionId);
+    assert.strictEqual(session.notes, 'New note');
+});


### PR DESCRIPTION
## Summary
- support updating and persisting session notes in `historyStore`
- add tests verifying session start, note updates, and retrieval using a mock filesystem
- include `mock-fs` as a dev dependency for isolated history tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bce5d8a0a88331b961f5cb4e8498d1